### PR TITLE
Use original title for viewer-sinatra pull requests

### DIFF
--- a/app/jobs/deploy_viewer_sinatra_pull_request_job.rb
+++ b/app/jobs/deploy_viewer_sinatra_pull_request_job.rb
@@ -20,7 +20,7 @@ class DeployViewerSinatraPullRequestJob
     updater.path = 'DATASOURCE'
     updater.branch = branch_name
     updater.update(countries_json_url)
-    pull_request = create_pull_request(updater.message)
+    pull_request = create_pull_request(pull_request_title)
     create_deployment_status(pull_request.html_url)
   end
 
@@ -87,6 +87,10 @@ class DeployViewerSinatraPullRequestJob
 
   def branch_name
     "everypolitician-data-pr-#{pull_request_number}"
+  end
+
+  def pull_request_title
+    everypolitician_data_pull_request.title
   end
 
   def create_deployment_status(target_url)

--- a/spec/deploy_viewer_sinatra_pull_request_job_spec.rb
+++ b/spec/deploy_viewer_sinatra_pull_request_job_spec.rb
@@ -8,7 +8,10 @@ describe DeployViewerSinatraPullRequestJob do
   let(:updater) { Minitest::Mock.new }
 
   it 'updates the DATASOURCE file in viewer-sinatra' do
-    pull = OpenStruct.new(head: OpenStruct.new(sha: 'abc123', ref: 'master'))
+    pull = OpenStruct.new(
+      head: OpenStruct.new(sha: 'abc123', ref: 'master'),
+      title: 'Updating Atlantis'
+    )
     pull_request = OpenStruct.new(html_url: 'https://example.org/pull_request/11')
     github.expect(:pull, pull, [ENV['EVERYPOLITICIAN_DATA_REPO'], 42])
     github_updater.expect(:new, updater, [ENV['VIEWER_SINATRA_REPO']])
@@ -26,7 +29,7 @@ describe DeployViewerSinatraPullRequestJob do
       ENV['VIEWER_SINATRA_REPO'],
       'master',
       'everypolitician-data-pr-42',
-      'Update DATASOURCE',
+      'Updating Atlantis',
       String
     ])
     github.expect(:create_deployment_status, true, [


### PR DESCRIPTION
When creating a viewer-sinatra pull request to match one in
everypolitician-data use the title of the original pull request rather
than using "Update DATASOURCE" for all of them.

Fixes #20 