### PR TITLE
Fix pull requests from forks

### DIFF
--- a/app/jobs/deploy_viewer_sinatra_pull_request_job.rb
+++ b/app/jobs/deploy_viewer_sinatra_pull_request_job.rb
@@ -29,7 +29,7 @@ class DeployViewerSinatraPullRequestJob
   def update_datasource
     countries_json_url = 'https://raw.githubusercontent.com/' \
       'everypolitician/everypolitician-data/' \
-      "#{everypolitician_data_pull_request.head.sha}/countries.json"
+      "#{deployment['deployment']['sha']}/countries.json"
     updater = github_updater.new(viewer_sinatra_repo)
     updater.path = 'DATASOURCE'
     updater.branch = branch_name

--- a/app/jobs/handle_everypolitician_data_pull_request_job.rb
+++ b/app/jobs/handle_everypolitician_data_pull_request_job.rb
@@ -38,7 +38,7 @@ class HandleEverypoliticianDataPullRequestJob
   def create_deployment_event
     github.create_deployment(
       everypolitician_data_repo,
-      pull_request['pull_request']['head']['ref'],
+      pull_request['pull_request']['head']['sha'],
       environment: 'viewer-sinatra',
       payload: { pull_request_number: pull_request['number'] }
     )

--- a/spec/deploy_viewer_sinatra_pull_request_job_spec.rb
+++ b/spec/deploy_viewer_sinatra_pull_request_job_spec.rb
@@ -42,6 +42,7 @@ describe DeployViewerSinatraPullRequestJob do
         'full_name' => ENV['EVERYPOLITICIAN_DATA_REPO']
       },
       'deployment' => {
+        'sha' => 'abc123',
         'payload' => {
           'pull_request_number' => 42
         },


### PR DESCRIPTION
After many failed attempts at complicated workarounds it turns out you can just use a SHA instead of a ref since SHAs are immediately visible in the source repository whereas refs (in this case branches) only exist in the fork at the time of the pull request.