### PR TITLE
Don't try to merge master into pull requests

### DIFF
--- a/app/jobs/handle_everypolitician_data_pull_request_job.rb
+++ b/app/jobs/handle_everypolitician_data_pull_request_job.rb
@@ -39,6 +39,7 @@ class HandleEverypoliticianDataPullRequestJob
     github.create_deployment(
       everypolitician_data_repo,
       pull_request['pull_request']['head']['sha'],
+      auto_merge: false,
       environment: 'viewer-sinatra',
       payload: { pull_request_number: pull_request['number'] }
     )


### PR DESCRIPTION
This can cause problems if external pull requests aren't up-to-date and
means that the deployments to viewer-sinatra fail. Since there needs to
be human intervention when the PR is merged anyway the merging can
happen at that point.

Fixes #34 