### PR TITLE
Submissions without moderation queue

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -23,4 +23,19 @@ class Application < Sequel::Model
   def generate_app_secret
     self.secret = SecureRandom.hex(20)
   end
+
+  def submission_from_payload(submission_data)
+    updates = submission_data.delete(:updates)
+    submission = nil
+    db.transaction do
+      submission = add_submission(submission_data)
+      updates.each do |field, value|
+        submission.add_update(
+          field: field,
+          value: value
+        )
+      end
+    end
+    submission
+  end
 end

--- a/db/migrations/008_change_submission_person_id_type.rb
+++ b/db/migrations/008_change_submission_person_id_type.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:submissions) do
+      set_column_type :person_id, String
+    end
+  end
+end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -15,4 +15,24 @@ describe Application do
   it 'gets a secret automatically on create' do
     assert subject.secret
   end
+
+  describe '#submission_from_payload' do
+    it 'creates a submission and associated updates' do
+      submission = subject.submission_from_payload(
+        country: 'Foo',
+        legislature: 'Bar',
+        person_id: '123',
+        updates: {
+          twitter: 'foobarbaz'
+        }
+      )
+      assert_equal 'Foo', submission.country
+      assert_equal 'Bar', submission.legislature
+      assert_equal '123', submission.person_id
+      assert_equal 1, submission.updates.count
+      update = submission.updates.first
+      assert_equal 'twitter', update.field
+      assert_equal 'foobarbaz', update.value
+    end
+  end
 end


### PR DESCRIPTION
Allow application to submit updates without needing to go though the moderation queue.

Related to https://github.com/everypolitician/app-manager/issues/26
Fixes https://github.com/everypolitician/app-manager/issues/11