### PR TITLE
Disable auto-merging viewer-sinatra pull requests

### DIFF
--- a/app/jobs/deploy_viewer_sinatra_pull_request_job.rb
+++ b/app/jobs/deploy_viewer_sinatra_pull_request_job.rb
@@ -18,8 +18,10 @@ class DeployViewerSinatraPullRequestJob
     update_datasource
     pull_request = create_pull_request(pull_request_title)
     create_deployment_status(pull_request.html_url)
-    return unless deployment['deployment']['payload']['merge']
-    github.merge_pull_request(viewer_sinatra_repo, pull_request[:number])
+    # TODO: Re-enable this once it handles waiting for the travis build to pass
+    # before merging.
+    # return unless deployment['deployment']['payload']['merge']
+    # github.merge_pull_request(viewer_sinatra_repo, pull_request[:number])
   end
 
   private


### PR DESCRIPTION
Stop automatically merging viewer-sinatra pull requests after updating
the 'DATASOURCE' to point at everypolitician-data's master branch.

We still update the viewer-sinatra pull request to point at master once
that matching everypolitician-data pull request is merged, but merging
it at the same time means that the travis build fails because the pull
request ref has been deleted when it runs.

I think we can possibly re-enable this by polling the GitHub status API
or something, but this at least stops the failed builds for now.