### PR TITLE
Handle failing webhooks

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -2,6 +2,14 @@
 class SendWebhookJob
   include Sidekiq::Worker
 
+  # Discard the job immediately if it fails.
+  #
+  # FIXME: This is OK for the webhook for all countries because that usually
+  # gets triggered multiple times per day. When we add webhooks for individual
+  # countries we should then consider adding some kind of retry mechanism as
+  # these won't be delivered as frequently.
+  sidekiq_options retry: false
+
   def perform(webhook_url)
     Faraday.post(webhook_url) do |req|
       req.body = countries_json

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -14,6 +14,8 @@ class SendWebhookJob
     Faraday.post(webhook_url) do |req|
       req.body = countries_json
       req.headers['Content-Type'] = 'application/json'
+      req.options.timeout = 10
+      req.options.open_timeout = 5
     end
   end
 


### PR DESCRIPTION
Don't retry the webhook for all countries as that gets delivered frequently enough that missing one isn't too much of a problem. This also reduces the timeout on the webhook so that the background job queue doesn't get too blocked waiting for webhooks.

Closes https://github.com/everypolitician/everypolitician/issues/212