### PR TITLE
Rollbar disable monkeypatching

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,6 +27,7 @@ configure do
     Rollbar.configure do |config|
       config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
       config.disable_monkey_patch = true
+      config.environment = :production
     end
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -141,12 +141,6 @@ get '/applications/:application_id/submissions/:id' do
   erb :new_submission
 end
 
-get '/rollbar_test' do
-  class RollbarTestingException < RuntimeError; end
-  Rollbar.error('Test error from rollbar_test')
-  raise RollbarTestingException.new, 'Testing rollbar. If you can see this, it works.'
-end
-
 # Mounted under /submissions so we can use basic auth
 class Submissions < Sinatra::Base
   use Rack::Auth::Basic do |application_id, secret|

--- a/app.rb
+++ b/app.rb
@@ -19,8 +19,14 @@ configure do
   set :github_webhook_secret, ENV['GITHUB_WEBHOOK_SECRET']
 
   if production?
+    require 'rollbar/middleware/sinatra'
+    require 'rollbar/sidekiq'
+
+    use Rollbar::Middleware::Sinatra
+
     Rollbar.configure do |config|
       config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+      config.disable_monkey_patch = true
     end
   end
 end


### PR DESCRIPTION
The monkeypatching that the rollbar gem does only seems to patch `Rack::Builder` and not Sinatra. So we do this manually, which is also a bit more explicit. I've also added a setting to specify the environment so that exceptions can be matched up to deploys.