### PR TITLE
Speed up nokogiri installs in everypolitician-data

### DIFF
--- a/app/jobs.rb
+++ b/app/jobs.rb
@@ -1,3 +1,8 @@
+# Lots of the background jobs run 'bundle install' in the everypolitician-data
+# repo. This can be very slow because nokogiri compiles it's own versions of
+# libxml and libxslt. Setting this environment variable should speed up the builds.
+ENV['NOKOGIRI_USE_SYSTEM_LIBRARIES'] = '1'
+
 require 'app/jobs/merge_job'
 require 'app/jobs/accept_submission_job'
 require 'app/jobs/deploy_viewer_sinatra_pull_request_job'


### PR DESCRIPTION
Lots of background jobs clone the everypolitician-data repo and then run
'bundle install'. This can be very slow as nokogiri compiles it's own
versions of libxml and libxslt, which Heroku already has installed.
Hopefully setting this env var should speed things up.