### PR TITLE
Try sending webhooks 3 times before failing

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -6,13 +6,8 @@ class SendWebhookJob
 
   include Sidekiq::Worker
 
-  # Discard the job immediately if it fails.
-  #
-  # FIXME: This is OK for the webhook for all countries because that usually
-  # gets triggered multiple times per day. When we add webhooks for individual
-  # countries we should then consider adding some kind of retry mechanism as
-  # these won't be delivered as frequently.
-  sidekiq_options retry: false
+  # Discard the job if it fails 3 times.
+  sidekiq_options retry: 3
 
   def perform(application_id, action, pull_request_number, pull_request_head)
     application = Application[application_id]


### PR DESCRIPTION
This is a workaround for `PG::ConnectionBad: PQconsumeInput() SSL
connection has been closed unexpectedly` errors on Heroku which have
started occurring more frequently now that the background jobs needs to
access the database.

Ideally this wouldn't be needed because the database would be reliable,
but this seems like the simplest fix in the short term.