### PR TITLE
Check database connections are valid before using

### DIFF
--- a/app/models.rb
+++ b/app/models.rb
@@ -1,3 +1,7 @@
+# http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_validator_rb.html
+Sinatra::Application.database.extension(:connection_validator)
+Sinatra::Application.database.pool.connection_validation_timeout = -1
+
 Sequel::Model.plugin :timestamps
 Sequel::Model.plugin :validation_helpers
 Sequel::Model.plugin :json_serializer


### PR DESCRIPTION
When a connection is pulled out of the connection pool perform a 'SELECT
NULL' operation on it to ensure it's still working, if it isn't then
keep trying with other pool connections, finally falling back to
creating a new connection is necessary.